### PR TITLE
style: add mono style for 1-bit displays

### DIFF
--- a/style/basic/basic.go
+++ b/style/basic/basic.go
@@ -11,14 +11,14 @@ import (
 	"tinygo.org/x/tinygl-font/roboto"
 )
 
-type Basic[T pixel.Color] struct {
+type Theme[T pixel.Color] struct {
 	style.Theme[T]
 }
 
-// NewTheme returns a new basic theme with the given properties.
+// New returns a new Basic Theme with the given properties.
 //
 // The default style is black text on a white background with a blue tint color.
-func NewTheme[T pixel.Color](scale style.Scale, screen *tinygl.Screen[T]) *Basic[T] {
+func New[T pixel.Color](scale style.Scale, screen *tinygl.Screen[T]) *Theme[T] {
 	// Pick a font that is suitable for the given scale.
 	// We can't just pick any size, so we have to use some heuristics.
 	percent := scale.Percent()
@@ -44,7 +44,7 @@ func NewTheme[T pixel.Color](scale style.Scale, screen *tinygl.Screen[T]) *Basic
 		font = roboto.Regular48
 	}
 
-	return &Basic[T]{
+	return &Theme[T]{
 		Theme: style.Theme[T]{
 			Screen:     screen,
 			Font:       font,

--- a/style/basic/objects.go
+++ b/style/basic/objects.go
@@ -5,17 +5,17 @@ import (
 )
 
 // Create a new text label with the default style.
-func (theme *Basic[T]) NewText(text string) *tinygl.Text[T] {
+func (theme *Theme[T]) NewText(text string) *tinygl.Text[T] {
 	return tinygl.NewText(theme.Font, theme.Foreground, theme.Background, text)
 }
 
 // NewVBox returns a new VBox with the default style.
-func (theme *Basic[T]) NewVBox(children ...tinygl.Object[T]) *tinygl.VBox[T] {
+func (theme *Theme[T]) NewVBox(children ...tinygl.Object[T]) *tinygl.VBox[T] {
 	return tinygl.NewVBox(theme.Background, children...)
 }
 
 // Create a new listbox with the given elements. The elements (and number of
 // elements) cannot be changed after creation.
-func (theme *Basic[T]) NewListBox(elements []string) *tinygl.ListBox[T] {
+func (theme *Theme[T]) NewListBox(elements []string) *tinygl.ListBox[T] {
 	return tinygl.NewListBox(theme.Font, theme.Foreground, theme.Background, theme.Tint, elements)
 }

--- a/style/mono/mono.go
+++ b/style/mono/mono.go
@@ -1,0 +1,56 @@
+package mono
+
+// The mono theme is a plain default style for monochrome displays.
+
+import (
+	"github.com/aykevl/tinygl"
+	"github.com/aykevl/tinygl/style"
+	"tinygo.org/x/drivers/pixel"
+	font "tinygo.org/x/tinygl-font"
+	"tinygo.org/x/tinygl-font/roboto"
+)
+
+type Mono[T pixel.Color] struct {
+	style.Theme[T]
+}
+
+// NewTheme returns a new basic theme with the given properties.
+//
+// The default style is black text on a white background.
+func NewTheme[T pixel.Color](scale style.Scale, screen *tinygl.Screen[T]) *Mono[T] {
+	// Pick a font that is suitable for the given scale.
+	// We can't just pick any size, so we have to use some heuristics.
+	percent := scale.Percent()
+	var font font.Font
+	switch {
+	case percent <= 100:
+		font = roboto.Regular16
+	case percent <= 125:
+		font = roboto.Regular20
+	case percent <= 150:
+		font = roboto.Regular24
+	case percent <= 175:
+		font = roboto.Regular28
+	case percent <= 200:
+		font = roboto.Regular32
+	case percent <= 225:
+		font = roboto.Regular36
+	case percent <= 250:
+		font = roboto.Regular40
+	case percent <= 275:
+		font = roboto.Regular44
+	default: // 300% and larger
+		font = roboto.Regular48
+	}
+
+	return &Mono[T]{
+		Theme: style.Theme[T]{
+			Screen:     screen,
+			Font:       font,
+			Foreground: pixel.NewColor[T](255, 255, 255), // black
+			Background: pixel.NewColor[T](0, 0, 0),       // white
+			Tint:       pixel.NewColor[T](0, 0, 0),       // white
+			Scale:      scale,
+		},
+	}
+}

--- a/style/mono/mono.go
+++ b/style/mono/mono.go
@@ -10,14 +10,14 @@ import (
 	"tinygo.org/x/tinygl-font/roboto"
 )
 
-type Mono[T pixel.Color] struct {
+type Theme[T pixel.Color] struct {
 	style.Theme[T]
 }
 
-// NewTheme returns a new basic theme with the given properties.
+// New returns a new Mono theme with the given properties.
 //
 // The default style is black text on a white background.
-func NewTheme[T pixel.Color](scale style.Scale, screen *tinygl.Screen[T]) *Mono[T] {
+func New[T pixel.Color](scale style.Scale, screen *tinygl.Screen[T]) *Theme[T] {
 	// Pick a font that is suitable for the given scale.
 	// We can't just pick any size, so we have to use some heuristics.
 	percent := scale.Percent()
@@ -43,7 +43,7 @@ func NewTheme[T pixel.Color](scale style.Scale, screen *tinygl.Screen[T]) *Mono[
 		font = roboto.Regular48
 	}
 
-	return &Mono[T]{
+	return &Theme[T]{
 		Theme: style.Theme[T]{
 			Screen:     screen,
 			Font:       font,

--- a/style/mono/objects.go
+++ b/style/mono/objects.go
@@ -1,0 +1,21 @@
+package mono
+
+import (
+	"github.com/aykevl/tinygl"
+)
+
+// Create a new text label with the default style.
+func (theme *Mono[T]) NewText(text string) *tinygl.Text[T] {
+	return tinygl.NewText(theme.Font, theme.Foreground, theme.Background, text)
+}
+
+// NewVBox returns a new VBox with the default style.
+func (theme *Mono[T]) NewVBox(children ...tinygl.Object[T]) *tinygl.VBox[T] {
+	return tinygl.NewVBox(theme.Background, children...)
+}
+
+// Create a new listbox with the given elements. The elements (and number of
+// elements) cannot be changed after creation.
+func (theme *Mono[T]) NewListBox(elements []string) *tinygl.ListBox[T] {
+	return tinygl.NewListBox(theme.Font, theme.Foreground, theme.Background, theme.Tint, elements)
+}

--- a/style/mono/objects.go
+++ b/style/mono/objects.go
@@ -5,17 +5,17 @@ import (
 )
 
 // Create a new text label with the default style.
-func (theme *Mono[T]) NewText(text string) *tinygl.Text[T] {
+func (theme *Theme[T]) NewText(text string) *tinygl.Text[T] {
 	return tinygl.NewText(theme.Font, theme.Foreground, theme.Background, text)
 }
 
 // NewVBox returns a new VBox with the default style.
-func (theme *Mono[T]) NewVBox(children ...tinygl.Object[T]) *tinygl.VBox[T] {
+func (theme *Theme[T]) NewVBox(children ...tinygl.Object[T]) *tinygl.VBox[T] {
 	return tinygl.NewVBox(theme.Background, children...)
 }
 
 // Create a new listbox with the given elements. The elements (and number of
 // elements) cannot be changed after creation.
-func (theme *Mono[T]) NewListBox(elements []string) *tinygl.ListBox[T] {
+func (theme *Theme[T]) NewListBox(elements []string) *tinygl.ListBox[T] {
 	return tinygl.NewListBox(theme.Font, theme.Foreground, theme.Background, theme.Tint, elements)
 }


### PR DESCRIPTION
This PR adds a new very basic style named `mono` for monochrome displays such as e-ink.