### PR TITLE
Export Object and BaseObject definitions

### DIFF
--- a/gfx/canvas.go
+++ b/gfx/canvas.go
@@ -160,8 +160,8 @@ func (c *Canvas[T]) setDirty(blockX, blockY int) {
 	c.dirty[blockNum/8] |= (1 << (blockNum % 8))
 }
 
-// markDirty marks all tiles in the given rectangle as dirty.
-func (c *Canvas[T]) markDirty(x, y, width, height int) {
+// MarkDirty marks all tiles in the given rectangle as dirty.
+func (c *Canvas[T]) MarkDirty(x, y, width, height int) {
 	if x < 0 {
 		width -= x
 		x = 0
@@ -218,7 +218,7 @@ func (c *Canvas[T]) Clear() {
 // Add a previously created object to the canvas. An object can't be added more
 // than once.
 func (c *Canvas[T]) Add(object Object[T]) {
-	object.setCanvas(c)
-	object.markDirty()
+	object.SetCanvas(c)
+	object.MarkDirty()
 	c.objects = append(c.objects, object)
 }

--- a/gfx/circle.go
+++ b/gfx/circle.go
@@ -4,7 +4,7 @@ import "tinygo.org/x/drivers/pixel"
 
 // Circle is a simple solid color circle.
 type Circle[T pixel.Color] struct {
-	baseObject[T]
+	BaseObject[T]
 	radius int16
 	color  T
 	hidden bool
@@ -20,9 +20,9 @@ type Circle[T pixel.Color] struct {
 // borders are added.
 func NewCircle[T pixel.Color](color T, x, y, radius int) *Circle[T] {
 	return &Circle[T]{
-		baseObject: baseObject[T]{
-			x: int16(x),
-			y: int16(y),
+		BaseObject: BaseObject[T]{
+			X: int16(x),
+			Y: int16(y),
 		},
 		radius: int16(radius),
 		color:  color,
@@ -47,10 +47,10 @@ func (obj *Circle[T]) Draw(imgX, imgY int, img pixel.Image[T]) {
 	// least for whole-screen updates, it doesn't matter as img will usually be
 	// the width of the screen anyway.
 	_, imgHeight := img.Size()
-	if imgY > int(obj.y)+int(obj.radius) {
+	if imgY > int(obj.Y)+int(obj.radius) {
 		return
 	}
-	if imgY+imgHeight < int(obj.y)-int(obj.radius) {
+	if imgY+imgHeight < int(obj.Y)-int(obj.radius) {
 		return
 	}
 
@@ -58,8 +58,8 @@ func (obj *Circle[T]) Draw(imgX, imgY int, img pixel.Image[T]) {
 	// We do this by treating the circle as two halves split horizontally in the
 	// middle. We draw line by line, starting at the middle most lines working
 	// towards the top and the bottom at the same time.
-	x := int(obj.x) - imgX
-	y := int(obj.y) - imgY
+	x := int(obj.X) - imgX
+	y := int(obj.Y) - imgY
 	cx := int(obj.radius) - 1
 	r2 := int(obj.radius) * int(obj.radius) // r²
 	aaCutoff := int(obj.radius) * 2         // why this value??
@@ -122,12 +122,12 @@ func (obj *Circle[T]) Draw(imgX, imgY int, img pixel.Image[T]) {
 	}
 }
 
-func (obj *Circle[T]) markDirty() {
-	x := int(obj.x) - int(obj.radius)
-	y := int(obj.y) - int(obj.radius)
+func (obj *Circle[T]) MarkDirty() {
+	x := int(obj.X) - int(obj.radius)
+	y := int(obj.Y) - int(obj.radius)
 	w := int(obj.radius) * 2
 	h := int(obj.radius) * 2
-	obj.canvas.markDirty(x, y, w, h)
+	obj.Canvas.MarkDirty(x, y, w, h)
 }
 
 // Hidden returns whether this object is currently hidden.
@@ -140,6 +140,6 @@ func (obj *Circle[T]) Hidden() bool {
 func (obj *Circle[T]) SetHidden(hidden bool) {
 	if obj.hidden != hidden {
 		obj.hidden = hidden
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }

--- a/gfx/image.go
+++ b/gfx/image.go
@@ -7,7 +7,7 @@ import (
 
 // Image wraps an image.Image object to be drawn on a canvas.
 type Image[T pixel.Color] struct {
-	baseObject[T]
+	BaseObject[T]
 	hidden bool
 	scale  uint8
 	img    image.Image[T]
@@ -16,9 +16,9 @@ type Image[T pixel.Color] struct {
 // NewImage creates a new image not yet attached to a canvas.
 func NewImage[T pixel.Color](img image.Image[T], x, y int) *Image[T] {
 	return &Image[T]{
-		baseObject: baseObject[T]{
-			x: int16(x),
-			y: int16(y),
+		BaseObject: BaseObject[T]{
+			X: int16(x),
+			Y: int16(y),
 		},
 		scale: 1,
 		img:   img,
@@ -30,28 +30,28 @@ func (obj *Image[T]) Draw(bufX, bufY int, buf pixel.Image[T]) {
 	if obj.hidden {
 		return
 	}
-	obj.img.Draw(buf, bufX-int(obj.x), bufY-int(obj.y), int(obj.scale))
+	obj.img.Draw(buf, bufX-int(obj.X), bufY-int(obj.Y), int(obj.scale))
 }
 
 // Bounds returns the rectangle coordinates relative to (0, 0) of the canvas.
 func (obj *Image[T]) Bounds() (x, y, width, height int) {
 	imageWidth, imageHeight := obj.img.Size()
 	scale := int(obj.scale)
-	return int(obj.x), int(obj.y), imageWidth * scale, imageHeight * scale
+	return int(obj.X), int(obj.Y), imageWidth * scale, imageHeight * scale
 }
 
 // Move the rectangle to the new coordinates.
 func (obj *Image[T]) Move(x, y int) {
-	if x == int(obj.x) && y == int(obj.y) {
+	if x == int(obj.X) && y == int(obj.Y) {
 		return
 	}
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
-	obj.x = int16(x)
-	obj.y = int16(y)
+	obj.X = int16(x)
+	obj.Y = int16(y)
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }
 
@@ -61,11 +61,11 @@ func (obj *Image[T]) SetImage(img image.Image[T]) {
 		return
 	}
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 	obj.img = img
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }
 
@@ -78,17 +78,17 @@ func (obj *Image[T]) SetScale(scale int) {
 		return
 	}
 	if int(obj.scale) > scale && !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 	obj.scale = uint8(scale)
 	if int(obj.scale) < scale && !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }
 
-func (obj *Image[T]) markDirty() {
+func (obj *Image[T]) MarkDirty() {
 	imageWidth, imageHeight := obj.img.Size()
-	obj.canvas.markDirty(int(obj.x), int(obj.y), imageWidth, imageHeight)
+	obj.Canvas.MarkDirty(int(obj.X), int(obj.Y), imageWidth, imageHeight)
 }
 
 // Hidden returns whether this object is currently hidden.
@@ -101,6 +101,6 @@ func (obj *Image[T]) Hidden() bool {
 func (obj *Image[T]) SetHidden(hidden bool) {
 	if obj.hidden != hidden {
 		obj.hidden = hidden
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }

--- a/gfx/line.go
+++ b/gfx/line.go
@@ -6,8 +6,8 @@ import (
 
 // Line is a line from a start coordinate to an end coordinate.
 type Line[T pixel.Color] struct {
-	baseObject[T]
-	x2, y2      int16 // x1, y1 are x, y
+	BaseObject[T]
+	X2, Y2      int16 // x1, y1 are x, y
 	strokeWidth int16 // line width in pixels
 	color       T
 	hidden      bool
@@ -22,12 +22,12 @@ type Line[T pixel.Color] struct {
 // property. Lines by default have an ending like SVG stroke-linecap="butt".
 func NewLine[T pixel.Color](color T, x1, y1, x2, y2, strokeWidth int) *Line[T] {
 	line := &Line[T]{
-		baseObject: baseObject[T]{
-			x: int16(x1),
-			y: int16(y1),
+		BaseObject: BaseObject[T]{
+			X: int16(x1),
+			Y: int16(y1),
 		},
-		x2:          int16(x2),
-		y2:          int16(y2),
+		X2:          int16(x2),
+		Y2:          int16(y2),
 		strokeWidth: int16(strokeWidth),
 		color:       color,
 	}
@@ -50,10 +50,10 @@ func (obj *Line[T]) updatePolygon() {
 		return
 	}
 
-	x1 := int(obj.x)
-	y1 := int(obj.y)
-	x2 := int(obj.x2)
-	y2 := int(obj.y2)
+	x1 := int(obj.X)
+	y1 := int(obj.Y)
+	x2 := int(obj.X2)
+	y2 := int(obj.Y2)
 
 	if y1 == y2 {
 		// Straight horizontal line.
@@ -203,10 +203,10 @@ func (obj *Line[T]) Draw(imgX, imgY int, img pixel.Image[T]) {
 		return
 	}
 
-	x1 := int(obj.x) - imgX
-	y1 := int(obj.y) - imgY
-	x2 := int(obj.x2) - imgX
-	y2 := int(obj.y2) - imgY
+	x1 := int(obj.X) - imgX
+	y1 := int(obj.Y) - imgY
+	x2 := int(obj.X2) - imgX
+	y2 := int(obj.Y2) - imgY
 
 	if y1 == y2 {
 		// Fast path: draw horizontal line.
@@ -230,7 +230,7 @@ func (obj *Line[T]) Draw(imgX, imgY int, img pixel.Image[T]) {
 	drawPolygon(&obj.polygon, img, imgX, imgY, obj.color)
 }
 
-func (obj *Line[T]) markDirty() {
+func (obj *Line[T]) MarkDirty() {
 	thickness := int(obj.strokeWidth)
 	if thickness == 0 {
 		// The line is invisible.
@@ -241,24 +241,24 @@ func (obj *Line[T]) markDirty() {
 	// It's possible to optimize this, essentially by running the polygon
 	// filling algorithm algorithm again but at blockSize-sized pixels (the
 	// canvas tile size). But for now, this works.
-	obj.canvas.markDirty(int(obj.polygon.boundX1), int(obj.polygon.boundY1), int(obj.polygon.boundX2-obj.polygon.boundX1), int(obj.polygon.boundY2-obj.polygon.boundY1))
+	obj.Canvas.MarkDirty(int(obj.polygon.boundX1), int(obj.polygon.boundY1), int(obj.polygon.boundX2-obj.polygon.boundX1), int(obj.polygon.boundY2-obj.polygon.boundY1))
 }
 
 // Set the line position (start and end point).
 func (obj *Line[T]) SetPosition(x1, y1, x2, y2 int) {
-	if int(obj.x) == x1 && int(obj.y) == y1 && int(obj.x2) == x2 && int(obj.y2) == y2 {
+	if int(obj.X) == x1 && int(obj.Y) == y1 && int(obj.X2) == x2 && int(obj.Y2) == y2 {
 		return
 	}
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
-	obj.x = int16(x1)
-	obj.y = int16(y1)
-	obj.x2 = int16(x2)
-	obj.y2 = int16(y2)
+	obj.X = int16(x1)
+	obj.Y = int16(y1)
+	obj.X2 = int16(x2)
+	obj.Y2 = int16(y2)
 	obj.updatePolygon()
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }
 
@@ -272,6 +272,6 @@ func (obj *Line[T]) Hidden() bool {
 func (obj *Line[T]) SetHidden(hidden bool) {
 	if obj.hidden != hidden {
 		obj.hidden = hidden
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }

--- a/gfx/object.go
+++ b/gfx/object.go
@@ -13,25 +13,25 @@ type Object[T pixel.Color] interface {
 	SetHidden(bool)
 
 	// Set the canvas property of an object. This can only be done once.
-	setCanvas(canvas *Canvas[T])
+	SetCanvas(canvas *Canvas[T])
 
 	// markDirty marks the blocks that this object occupies as dirty so that
 	// they will be redrawn on the next update.
-	markDirty()
+	MarkDirty()
 }
 
-// baseObject implements common methods on objects.
-type baseObject[T pixel.Color] struct {
-	canvas *Canvas[T]
-	x      int16
-	y      int16
+// BaseObject implements common methods on objects.
+type BaseObject[T pixel.Color] struct {
+	Canvas *Canvas[T]
+	X      int16
+	Y      int16
 }
 
-func (obj *baseObject[T]) setCanvas(canvas *Canvas[T]) {
-	if obj.canvas != nil {
+func (obj *BaseObject[T]) SetCanvas(canvas *Canvas[T]) {
+	if obj.Canvas != nil {
 		panic("gfx: object added twice to canvas")
 	}
-	obj.canvas = canvas
+	obj.Canvas = canvas
 }
 
 // True if the target architecture has pointers that are 16 bits or smaller.

--- a/gfx/rect.go
+++ b/gfx/rect.go
@@ -4,7 +4,7 @@ import "tinygo.org/x/drivers/pixel"
 
 // Rect is a simple solid color rectangle.
 type Rect[T pixel.Color] struct {
-	baseObject[T]
+	BaseObject[T]
 	width  int16
 	height int16
 	color  T
@@ -14,9 +14,9 @@ type Rect[T pixel.Color] struct {
 // NewRect returns a new rectangle of the given size to be added to the canvas.
 func NewRect[T pixel.Color](color T, x, y, width, height int) *Rect[T] {
 	return &Rect[T]{
-		baseObject: baseObject[T]{
-			x: int16(x),
-			y: int16(y),
+		BaseObject: BaseObject[T]{
+			X: int16(x),
+			Y: int16(y),
 		},
 		width:  int16(width),
 		height: int16(height),
@@ -29,12 +29,12 @@ func (obj *Rect[T]) Draw(imgX, imgY int, img pixel.Image[T]) {
 	if obj.hidden {
 		return
 	}
-	drawRect(img, obj.color, int(obj.x)-imgX, int(obj.y)-imgY, int(obj.width), int(obj.height))
+	drawRect(img, obj.color, int(obj.X)-imgX, int(obj.Y)-imgY, int(obj.width), int(obj.height))
 }
 
 // Bounds returns the rectangle coordinates relative to (0, 0) of the canvas.
 func (obj *Rect[T]) Bounds() (x, y, width, height int) {
-	return int(obj.x), int(obj.y), int(obj.width), int(obj.height)
+	return int(obj.X), int(obj.Y), int(obj.width), int(obj.height)
 }
 
 // Move the rectangle to the new coordinates.
@@ -42,21 +42,21 @@ func (obj *Rect[T]) Move(x, y int) {
 	// TODO: be smarter and only invalidate the area that is actually dirty (the
 	// rect is a solid color, so if it only moved a little bit most of the
 	// screen doesn't need to update).
-	if x == int(obj.x) && y == int(obj.y) {
+	if x == int(obj.X) && y == int(obj.Y) {
 		return
 	}
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
-	obj.x = int16(x)
-	obj.y = int16(y)
+	obj.X = int16(x)
+	obj.Y = int16(y)
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }
 
-func (obj *Rect[T]) markDirty() {
-	obj.canvas.markDirty(int(obj.x), int(obj.y), int(obj.width), int(obj.height))
+func (obj *Rect[T]) MarkDirty() {
+	obj.Canvas.MarkDirty(int(obj.X), int(obj.Y), int(obj.width), int(obj.height))
 }
 
 // Hidden returns whether this object is currently hidden.
@@ -69,7 +69,7 @@ func (obj *Rect[T]) Hidden() bool {
 func (obj *Rect[T]) SetHidden(hidden bool) {
 	if obj.hidden != hidden {
 		obj.hidden = hidden
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }
 
@@ -80,7 +80,7 @@ func (obj *Rect[T]) SetColor(color T) {
 	}
 	obj.color = color
 	if !obj.hidden {
-		obj.markDirty()
+		obj.MarkDirty()
 	}
 }
 


### PR DESCRIPTION
I faced the situation I wanted to experiment with new custom gfx components within my project. 
Some of these new gfx components can be very specific and may not be merged in tinygl.
 
With current TinyGL, it's not possible to have graphics components in your project source tree, because there are some unexported structs/methods. 

This PR changes some BaseObject/Object definitions to have them exported and allows external uses. 

What is your opinion on this approach ? 