### PR TITLE
line: (posssible) error in in polygon updateBounds when lines nearly vertical

### DIFF
--- a/gfx/polygon.go
+++ b/gfx/polygon.go
@@ -264,7 +264,7 @@ func (p *polygon) updateBounds() {
 			polygonY2 = ybottom
 		}
 		edgeX1 := edge.xstart
-		edgeX2 := edge.xstart + (ybottom-ytop)*edge.xinc
+		edgeX2 := edge.xstart + (ybottom-ytop)*edge.xinc/4
 		if edgeX1 > edgeX2 {
 			edgeX2, edgeX1 = edgeX1, edgeX2
 		}


### PR DESCRIPTION
With current main branch, I could observe the polygon's updateBounds is wrong when line almost vertical (not fully vertical). 

You can see on this video the screen redraw is too large when gauge hand is almost vertical: 

https://github.com/user-attachments/assets/8fd4dfe8-9c86-473e-b9ae-7d1f827c1f1c

Without certitude, I guess this is related to a misuse of `edge.xinc `which is not divided by 4 (like it is in other parts of the code, and because of the 4 lines antialiasing trick) 

Here is what it looks like with the fix. 

https://github.com/user-attachments/assets/9c3c7777-93fc-4ac4-a62f-3ffc2ada8220

You'll notice the redraw area is more limited when the hand is about 12PM

Thanks for your review